### PR TITLE
Allow only dates keys as dateFields

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "parse-json-with-dates",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "description": "Parse JSON casting date fields",
   "main": "lib/index.js",
   "devDependencies": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,10 +1,19 @@
 type DataType = {
-  [key: string]: boolean
+  [key: string]: true
 }
 
-export const parseJsonWithDates = <T>(
+type DateKeys<T> = string &
+  {
+    [P in keyof T]: T[P] extends Date
+      ? P
+      : T[P] extends object
+      ? DateKeys<T[P]>
+      : never
+  }[keyof T]
+
+export const parseJsonWithDates = <T = any>(
   text: string,
-  dateFields: string[] = []
+  dateFields: DateKeys<T>[] = []
 ): T => {
   const data: DataType = {}
 
@@ -22,5 +31,5 @@ export const parseJsonWithDates = <T>(
 }
 
 if (typeof window !== 'undefined') {
-  (window as any).parseJsonWithDates = parseJsonWithDates
+  ;(window as any).parseJsonWithDates = parseJsonWithDates
 }


### PR DESCRIPTION
- Allows to pass as dateFields recursively only keys with value of type Date
- Defaults parsed type with any if not specified
- Boolean true literal instead of boolean on internal object map
- Increments version to 0.0.4

![image](https://user-images.githubusercontent.com/18562820/104090780-4d84c780-5279-11eb-9a08-e4ddd113a58a.png)
